### PR TITLE
docker: Apple M1 support

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,23 +12,6 @@
 version: "3.8"
 services:
 
-  # We only need this during development to mock real `Bitrix` instance:
-  bitrix:
-    image: "vimagick/json-server:latest"
-    entrypoint: ''
-    command: node server.js
-    ports:
-      # Access it as "https://127.0.0.1:3045/" locally
-      # Local connection will be insecure, that's fine.
-      - "3045:3045"
-    volumes:
-      - ./docker/bitrix:/data
-    networks:
-      - bitrixnet
-    environment:
-      NODE_PATH: '/usr/lib/node_modules'
-    env_file: ./config/.env
-
   web:
     ports:
       # We only bind ports directly in development:
@@ -36,8 +19,6 @@ services:
     volumes:
       # We only mount source code in development:
       - .:/code
-    networks:
-      - bitrixnet
     build:
       # Needed for fixing permissions of files created by Docker
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ version: "3.8"
 services:
   db:
     image: "postgres:14-alpine"
-    restart: unless-stopped
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 version: "3.8"
 services:
   db:
-    image: "postgres:14-alpine"
+    image: "postgres:13-alpine"
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -23,8 +23,6 @@ ENV DJANGO_ENV=${DJANGO_ENV} \
   PIP_NO_CACHE_DIR=1 \
   PIP_DISABLE_PIP_VERSION_CHECK=1 \
   PIP_DEFAULT_TIMEOUT=100 \
-  # dockerize:
-  DOCKERIZE_VERSION=v0.6.1 \
   # tini:
   TINI_VERSION=v0.19.0 \
   # poetry:
@@ -48,11 +46,7 @@ RUN apt-get update && apt-get upgrade -y \
     gettext \
     git \
     libpq-dev \
-  # Installing `dockerize` utility:
-  # https://github.com/jwilder/dockerize
-  && curl -sSLO "https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" \
-  && tar -C /usr/local/bin -xzvf "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" \
-  && rm "dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz" && dockerize --version \
+    wait-for-it \
   # Installing `tini` utility:
   # https://github.com/krallin/tini
   # Get architecture to download appropriate tini release:

--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -11,12 +11,14 @@ readonly cmd="$*"
 
 # We need this line to make sure that this container is started
 # after the one with postgres:
-dockerize \
-  -wait "tcp://${DJANGO_DATABASE_HOST}:${DJANGO_DATABASE_PORT}" \
-  -timeout 90s
+wait-for-it \
+  --host=${DJANGO_DATABASE_HOST} \
+  --port=${DJANGO_DATABASE_PORT} \
+  --timeout=90 \
+  --strict
 
 # It is also possible to wait for other services as well: redis, elastic, mongo
->&2 echo 'Postgres is up - continuing...'
+echo 'Postgres is up - continuing...'
 
 # Evaluating passed command (do not touch):
 # shellcheck disable=SC2086

--- a/docs/pages/template/overview.rst
+++ b/docs/pages/template/overview.rst
@@ -128,10 +128,6 @@ Some containers might have long starting times, for example:
 - ``rabbitmq``
 - frontend, like ``node.js``
 
-To be sure that container is started at the right time,
-we utilize ``dockerize`` `script <https://github.com/jwilder/dockerize>`_.
-It is executed inside ``docker/django/entrypoint.sh`` file.
-
 We start containers with ``tini``.
 Because this way we have a proper signal handling
 and eliminate zombie processes.


### PR DESCRIPTION
* Удалил сервис bitrix (насколько я понял, мы исользуем hosted-версию json-server)
* Починил всякие мелкие штуки в docker-compose
* Удалил dockerize в пользу кросс-платформенного wait-for-it (дай знать, если это нужно в wemake-django-template, сделаю ПР туда)